### PR TITLE
Fix: Docker build and README link issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here are some videos showcasing the pose tracking performance (tested on Lenovo 
 ## Quick start
 
 1. Clone this repo with `git clone --recurse-submodules https://github.com/tctco/STCS.git` to your computer and `cd STCS`
-2. Download the [trained models](/tctco/STCS/releases/download/v0.0.1/trained_models.tar) from the release page and place them inside `STCS/backend/trained_models`
+2. Download the [trained models](https://github.com/tctco/STCS/releases/download/v0.0.1/trained_models.tar) from the release page and place them inside `STCS/backend/trained_models`
 3. Build & run the docker container by `docker compose up` (this container is quite large ~30GB, I'm sorry)
 4. Open your browser and go to `localhost` (you can access segTracker.ai via WAN/LAN by your hosting IP as well)
 5. Convert your video to a codec supported by Chrome Edge browser (we only tested H264)

--- a/backend/Dockerfile-flask
+++ b/backend/Dockerfile-flask
@@ -3,16 +3,17 @@ FROM python:3.9-slim-buster
 WORKDIR /backend
 COPY . ./
 
-RUN echo "deb http://mirrors.aliyun.com/debian/ buster main non-free contrib" > /etc/apt/sources.list && \
-    echo "deb-src http://mirrors.aliyun.com/debian/ buster main non-free contrib" >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.aliyun.com/debian-security buster/updates main" >> /etc/apt/sources.list && \
-    echo "deb-src http://mirrors.aliyun.com/debian-security buster/updates main" >> /etc/apt/sources.list && \
-    echo "deb http://mirrors.aliyun.com/debian/ buster-updates main non-free contrib" >> /etc/apt/sources.list && \
-    echo "deb-src http://mirrors.aliyun.com/debian/ buster-updates main non-free contrib" >> /etc/apt/sources.list && \
-    pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/
+# RUN echo "deb http://mirrors.aliyun.com/debian/ buster main non-free contrib" > /etc/apt/sources.list && \
+#     echo "deb-src http://mirrors.aliyun.com/debian/ buster main non-free contrib" >> /etc/apt/sources.list && \
+#     echo "deb http://mirrors.aliyun.com/debian-security buster/updates main" >> /etc/apt/sources.list && \
+#     echo "deb-src http://mirrors.aliyun.com/debian-security buster/updates main" >> /etc/apt/sources.list && \
+#     echo "deb http://mirrors.aliyun.com/debian/ buster-updates main non-free contrib" >> /etc/apt/sources.list && \
+#     echo "deb-src http://mirrors.aliyun.com/debian/ buster-updates main non-free contrib" >> /etc/apt/sources.list && \
+#     pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/
 
-
-RUN apt-get update \
+RUN sed -i 's/http:\/\/deb.debian.org/http:\/\/archive.debian.org/g' /etc/apt/sources.list && \
+    sed -i 's/http:\/\/security.debian.org/http:\/\/archive.debian.org/g' /etc/apt/sources.list && \
+    apt-get update \
     && apt-get install -y libpq-dev ffmpeg libsm6 libxext6 gcc \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/backend/requirements-worker.txt
+++ b/backend/requirements-worker.txt
@@ -7,7 +7,7 @@ opencv-python-headless==4.8.0.76
 matplotlib==3.7.1
 networkx==2.8.4
 ultralytics==8.0.180
-lap==0.4.0
+lap==0.5.12
 scipy==1.10.1
 psycopg2==2.9.9
 Flask==2.2.3


### PR DESCRIPTION
- Update Dockerfile-flask to use Debian archive mirrors, resolving 404 errors during apt-get update.
- Adjust lap package version in requirements-worker.txt to fix C-extension compilation errors with Python 3.10.
- Correct the download link for trained models in README.md.